### PR TITLE
Add dependency typescript-generator

### DIFF
--- a/apart-manager-api-server/pom.xml
+++ b/apart-manager-api-server/pom.xml
@@ -23,6 +23,7 @@
         <testcontainers.version>1.17.6</testcontainers.version>
         <fmt.version>2.21</fmt.version>
         <snakeyaml.version>2.1</snakeyaml.version>
+        <typescript-generator.version>3.1.1185</typescript-generator.version>
     </properties>
 
     <dependencies>
@@ -79,6 +80,11 @@
             <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>cz.habarta.typescript-generator</groupId>
+            <artifactId>typescript-generator-maven-plugin</artifactId>
+            <version>${typescript-generator.version}</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -98,6 +104,29 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>cz.habarta.typescript-generator</groupId>
+                <artifactId>typescript-generator-maven-plugin</artifactId>
+                <version>${typescript-generator.version}</version>
+                <executions>
+                    <execution>
+                        <id>generate</id>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <phase>process-classes</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <jsonLibrary>jackson2</jsonLibrary>
+                    <classPatterns>
+                        <classPattern>com.inzynierka2k24.apiserver.model.*</classPattern>
+                        <classPattern>com.inzynierka2k24.apiserver.web.request.*</classPattern>
+                    </classPatterns>
+                    <outputKind>module</outputKind>
+                    <outputFile>../apart-manager-api-web/src/generated/index.d.ts</outputFile>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/apart-manager-api-web/src/generated/index.d.ts
+++ b/apart-manager-api-web/src/generated/index.d.ts
@@ -1,0 +1,73 @@
+/* tslint:disable */
+/* eslint-disable */
+// Generated using typescript-generator version 3.1.1185 on 2023-10-08 11:00:01.
+
+export interface Apartment {
+    id?: number;
+    dailyPrice: number;
+    title: string;
+    country: string;
+    city: string;
+    street: string;
+    buildingNumber: string;
+    apartmentNumber: string;
+}
+
+export interface Contact {
+    id?: number;
+    contactType: ContactType;
+    receiver: string;
+    message: string;
+}
+
+export interface ExternalAccount {
+    id?: number;
+    login: string;
+    password: string;
+    mail: string;
+    serviceType: ServiceType;
+}
+
+export interface ExternalOffer {
+    id?: number;
+    serviceType: ServiceType;
+    externalLink: string;
+}
+
+export interface Reservation {
+    id?: number;
+    startDate: Date;
+    endDate: Date;
+}
+
+export interface User {
+    id?: number;
+    login: string;
+    password: string;
+    mail: string;
+    active: boolean;
+    roles: string[];
+}
+
+export interface UserDetails {
+}
+
+export interface EditUserRequest {
+    password: string;
+    mail: string;
+}
+
+export interface LoginRequest {
+    login: string;
+    password: string;
+}
+
+export interface RegisterRequest {
+    login: string;
+    password: string;
+    mail: string;
+}
+
+export type ContactType = "UNKNOWN" | "CLEANING" | "MECHANIC" | "ELECTRICIAN";
+
+export type ServiceType = "UNKNOWN" | "AIRBNB" | "BOOKING";


### PR DESCRIPTION
Typescript-mapper mapuje wybrane klasy Javove do klas TS. Obecnie ustawiłem żeby mapował klasy z Model jako że nie mamy oddzielnie DTO zdefiniowanych, i typy Requestów. Goal generujący plik .d.ts to `mvn typescript-generator:generate`.
Plik generuje się prosto do modułu frontowego do /src/generated/

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205692327180805